### PR TITLE
Update setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,8 @@ echo "#########################"
 echo "Install base dependencies"
 echo "#########################"
 echo
+
+sudo apt update
 sudo apt install -y doxygen libeigen3-dev python3-catkin-tools python-pip
 pip install cpplint
 


### PR DESCRIPTION
`setup.sh` fails if `apt update` has not previously been issued (ie from a fresh docker container)